### PR TITLE
Fix trailing slash inconsistency in SPA URLs

### DIFF
--- a/scripts/generate-static-routes.js
+++ b/scripts/generate-static-routes.js
@@ -77,23 +77,17 @@ async function generateStaticRoutes() {
       `<title>${route.title} - tmn.nyc</title>`
     );
 
-    // Create directory if it doesn't exist
-    const routeDir = path.join(distPath, route.path);
-    if (route.path !== '/') {
-      fs.mkdirSync(routeDir, { recursive: true });
-    }
-
-    // Write the HTML file
+    // Write the HTML file as flat files (no directories)
     const outputPath = route.path === '/' 
       ? indexPath 
-      : path.join(routeDir, 'index.html');
+      : path.join(distPath, `${route.path.slice(1)}.html`); // Remove leading slash and add .html
     
     fs.writeFileSync(outputPath, routeHtml);
     console.log(`✅ Generated: ${route.path} -> ${outputPath}`);
   });
 
   console.log('\n🎉 Static route generation complete!');
-  console.log('📁 Each route now has its own index.html file for better SEO.');
+  console.log('📄 Each route now has its own .html file for better SEO and consistent URLs.');
 }
 
 generateStaticRoutes().catch(console.error);


### PR DESCRIPTION
Modify static route generation to create flat HTML files, ensuring consistent URLs without trailing slashes for both SPA navigation and direct access.

Previously, client-side routing in the SPA produced URLs without trailing slashes (e.g., `/about`), while server-side static file serving (e.g., GitHub Pages) for the same content resulted in URLs with trailing slashes (e.g., `/about/` from `dist/about/index.html`). This change standardizes URLs to consistently omit trailing slashes across all access methods.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccf7a22b-e8e6-4573-82ed-a3a9481170f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ccf7a22b-e8e6-4573-82ed-a3a9481170f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

